### PR TITLE
Linux proxy support for installer

### DIFF
--- a/Linux/arkos_install/Installer.py
+++ b/Linux/arkos_install/Installer.py
@@ -917,6 +917,9 @@ class Downloader(QtCore.QThread):
 		# Download the files and report their status
 		link = self.mirror_link + self.filename
 		try:
+			proxy = urllib2.ProxyHandler()
+			opener = urllib2.build_opener(proxy)
+			urllib2.install_opener(opener)
 			dl_file = urllib2.urlopen(link)
 		except urllib2.HTTPError, e:
 			self.queue.put(e.code)


### PR DESCRIPTION
This patch loads the proxy definition of the enviroment variables in Linux, and uses them to download arkOS.
